### PR TITLE
Set `shouldReloadAll` to true by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,8 @@ import Route from '@ember/routing/route';
 
 export default Route.extend({
   model(params/*, transition*/) {
-    return this.get('store').findAll('tumblr-post-text', {
+    return this.get('store').queryRecord('tumblr-post-text', {
       id: params.post_id
-    }).then(function (posts) {
-      return posts.get('firstObject');
     });
   }
 });

--- a/addon/adapters/tumblr-post.js
+++ b/addon/adapters/tumblr-post.js
@@ -32,15 +32,6 @@ export default DS.RESTAdapter.extend({
   type: '',
 
   /**
-   * Build path from type
-   * @returns {string} API path with type string appended
-   */
-  pathForType() {
-    const type = isPresent(this.get('type')) ? `/${this.get('type')}` : '';
-    return `posts${type}`;
-  },
-
-  /**
    * Build namespace from blogURL
    * @returns {string} Tumblr API namespace with blogURL appended
    */
@@ -49,8 +40,19 @@ export default DS.RESTAdapter.extend({
   }),
 
   /**
+   * Build path from type
+   * @method pathForType
+   * @returns {string} API path with type string appended
+   */
+  pathForType() {
+    const type = isPresent(this.get('type')) ? `/${this.get('type')}` : '';
+    return `posts${type}`;
+  },
+
+  /**
    * Build hash for AJAX call
    * Appends API key and sets data type
+   * @method ajaxOptions
    * @returns {object} hash of AJAX options
    */
   ajaxOptions() {
@@ -59,5 +61,16 @@ export default DS.RESTAdapter.extend({
     hash.data.api_key = this.get('apiKey');
     hash.dataType = 'jsonp';
     return hash;
+  },
+
+  /**
+   * We need to make sure the cache is fresh;
+   * if you load 1 post into the store,
+   * it won't fetch all posts later
+   * @method shouldReloadAll
+   * @returns {boolean}
+   */
+  shouldReloadAll() {
+    return true;
   }
 });

--- a/addon/serializers/tumblr-post.js
+++ b/addon/serializers/tumblr-post.js
@@ -54,10 +54,6 @@ export default DS.RESTSerializer.extend({
     return payload;
   },
 
-  normalizeQueryRecordResponse() {
-    return this.normalizeArrayResponse(...arguments)[0];
-  },
-
   /**
    * Convert date from Tumblr API format to ISO string
    *


### PR DESCRIPTION
We need to refresh the cache in case the user loaded an individual post into the store and now wants to retrieve all posts.

Also fix some things I missed in the previous change