### PR TITLE
Move truth helpers from devdependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-tumblr",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Ember Addon for integrating a Tumblr blog",
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.6.0",
-    "ember-cli-htmlbars": "^2.0.1"
+    "ember-cli-htmlbars": "^2.0.1",
+    "ember-truth-helpers": "^2.0.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
@@ -49,8 +50,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.0.0-beta.1",
-    "ember-source-channel-url": "^1.0.1",
-    "ember-truth-helpers": "^2.0.0",
+    "ember-source-channel-url": "^1.0.1",    
     "ember-try": "^0.2.23",
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-tumblr",
-  "version": "0.11.0",
+  "version": "0.10.0",
   "description": "Ember Addon for integrating a Tumblr blog",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Move truth helpers from devdependencies to dependencies.
Ember truth helpers were not installed by default but are now integral to the project.
Also bumped version number up to 0.11.0 as ember-tumblr now contains new functionality.

https://github.com/elwayman02/ember-tumblr/issues/178